### PR TITLE
unpatch only my patch

### DIFF
--- a/CustomSaber/Plugin.cs
+++ b/CustomSaber/Plugin.cs
@@ -113,7 +113,7 @@ namespace CustomSaber
             Console.WriteLine("Unloading GameCore");
             SceneManager.UnloadSceneAsync("GameCore");
             Console.WriteLine("Unloading harmony patches");
-            harmony.UnpatchAll();
+            harmony.UnpatchAll("CustomSaberHarmonyInstance");
         }
 
         public static List<string> RetrieveCustomSabers()


### PR DESCRIPTION
UnpatchAll() without namespace argument unpatches all harmony patches applied before the call.
It affects other plugin using harmony on around OnApplicationStart.